### PR TITLE
feat: Add stopping error as a log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,18 @@ $ time python fit_analysis.py -c config/1Lbb.json -b numpy
 ## Observed behavior
 
 Things will all start without any problems, but nothing ever gets run
+
+## Note on troubleshooting `funcx-endpoint stop pyhf`
+
+At the end of this running
+
+```console
+$ funcx-endpoint stop pyhf
+```
+
+will result in the error seen in `stop-error.log.txt`. As this needs to get debugged, the only way I've found so far to shut things down is to run the following
+
+```console
+$ rm -rf ~/.funcx
+$ killall funcx-endpoint  # Run repeatedly until returns 'no process found'
+```

--- a/create_env.sh
+++ b/create_env.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Supress prompt changing warning
-export PYENV_VIRTUALENV_DISABLE_PROMPT=1
-
 pyenv deactivate
 pyenv virtualenv 3.8.11 pyhf-funcx
 pyenv activate pyhf-funcx

--- a/stop-error.log.txt
+++ b/stop-error.log.txt
@@ -1,0 +1,64 @@
+(pyhf-funcx) [feickert@hal-dgx dgx-funcx-minimal-example]$ funcx-endpoint stop pyhf
+Traceback (most recent call last):
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_common.py", line 447, in wrapper
+    ret = self._cache[fun]
+AttributeError: _cache
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_pslinux.py", line 1576, in wrapper
+    return fun(self, *args, **kwargs)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_common.py", line 450, in wrapper
+    return fun(self)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_pslinux.py", line 1618, in _parse_stat_file
+    with open_binary("%s/%s/stat" % (self._procfs_path, self.pid)) as f:
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_common.py", line 711, in open_binary
+    return open(fname, "rb", **kwargs)
+FileNotFoundError: [Errno 2] No such file or directory: '/proc/9965/stat'
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/__init__.py", line 354, in _init
+    self.create_time()
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/__init__.py", line 710, in create_time
+    self._create_time = self._proc.create_time()
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_pslinux.py", line 1576, in wrapper
+    return fun(self, *args, **kwargs)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_pslinux.py", line 1788, in create_time
+    ctime = float(self._parse_stat_file()['create_time'])
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/_pslinux.py", line 1583, in wrapper
+    raise NoSuchProcess(self.pid, self._name)
+psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=9965)
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/bin/funcx-endpoint", line 8, in <module>
+    sys.exit(cli_run())
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/funcx_endpoint/endpoint/endpoint.py", line 188, in cli_run
+    app()
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/typer/main.py", line 214, in __call__
+    return get_command(self)(*args, **kwargs)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/click/core.py", line 829, in __call__
+    return self.main(*args, **kwargs)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/click/core.py", line 782, in main
+    rv = self.invoke(ctx)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
+    return _process_result(sub_ctx.command.invoke(sub_ctx))
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
+    return ctx.invoke(self.callback, **ctx.params)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/click/core.py", line 610, in invoke
+    return callback(*args, **kwargs)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/typer/main.py", line 497, in wrapper
+    return callback(**use_params)  # type: ignore
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/funcx_endpoint/endpoint/endpoint.py", line 125, in stop_endpoint
+    manager.stop_endpoint(name)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/funcx_endpoint/endpoint/endpoint_manager.py", line 337, in stop_endpoint
+    parent = psutil.Process(pid)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/__init__.py", line 326, in __init__
+    self._init(pid)
+  File "/raid/projects/feickert/.pyenv/versions/pyhf-funcx/lib/python3.8/site-packages/psutil/__init__.py", line 367, in _init
+    raise NoSuchProcess(pid, None, msg)
+psutil.NoSuchProcess: psutil.NoSuchProcess no process found with pid 9965


### PR DESCRIPTION
```
* Add log file of error seen from trying to stop funcx-endpoint
* Note bad workaround solution in README
* Remove `PYENV_VIRTUALENV_DISABLE_PROMPT=1` from create_env.sh
```